### PR TITLE
Fix port/stats overlap on narrow screens (mobile portrait) #47

### DIFF
--- a/dockermanager/style.css
+++ b/dockermanager/style.css
@@ -399,6 +399,26 @@ select::-ms-expand {
   #search-input {
     width: 100%;
   }
+
+  /* Container cards: stack vertically on narrow screens */
+  .container-card {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+  .container-info {
+    width: 100%;
+  }
+  .container-ports {
+    white-space: normal;
+    word-break: break-all;
+    margin-right: 0;
+    flex: 1 1 auto;
+    min-width: 0;
+    margin-top: 6px;
+  }
+  .container-stats {
+    gap: 8px;
+  }
 }
 
 #version-stamp {

--- a/dockermanager/style.css
+++ b/dockermanager/style.css
@@ -400,7 +400,10 @@ select::-ms-expand {
     width: 100%;
   }
 
-  /* Container cards: stack vertically on narrow screens */
+}
+
+@media (max-width: 480px) and (orientation: portrait) {
+  /* Container cards: stack vertically on phones in portrait orientation */
   .container-card {
     flex-wrap: wrap;
     align-items: flex-start;


### PR DESCRIPTION
Add responsive CSS rules for screens <= 480px wide and in portrait mode, so container cards stack vertically instead of overflowing: info takes full width, ports wrap instead of staying no wrap, actions stay inline.

Fixes #47

