### PR TITLE
docs: fix typo in manual AUR installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ paru cockpit-dockermanager
 
 ```shell
 git clone https://aur.archlinux.org/cockpit-dockermanager.git
-cd cockpit-dockermanager-git
+cd cockpit-dockermanager
 makepkg -si
 ```
 </details>


### PR DESCRIPTION
There is a typo in the `cd`command from the previous git version in the README for the manual AUR Arch Linux installation instruction. 

